### PR TITLE
fix: parent nodes with no children can be selected

### DIFF
--- a/src/hooks/use-item.ts
+++ b/src/hooks/use-item.ts
@@ -57,7 +57,7 @@ export const useItem = <T>({
         switch (true) {
           case item.disabled ||
             !item.childLoaded ||
-            (item.canExpand && item.items.length === 0):
+            (item.canExpand && childIds.length === 0):
             return CheckboxStatus.disabled;
           case !item.canExpand && selectedIds.includes(item.id):
             return CheckboxStatus.checked;


### PR DESCRIPTION
### Summary

Fixed parent nodes with no children can be selected.

### Related Issues

Closes #17

### Screenshots

![image](https://github.com/mints-components/miller-columns/assets/37237996/06a89dc2-0287-4cba-8368-d16f613cf732)